### PR TITLE
nav-footer link fix

### DIFF
--- a/sass/layout/_footer.sass
+++ b/sass/layout/_footer.sass
@@ -32,6 +32,7 @@ footer
 .nav-footer
   display: flex
   justify-content: space-around
+  position: relative
   margin: 0 auto
 
   a


### PR DESCRIPTION
For some reason the links in the nav-footer are not clickable. The only fix I have been able to come up with for this is to add a relative positioning to .nav-footer. It does not appear as though there is an overlapping issue or a z-index would have corrected this. This definitely works, though :D